### PR TITLE
Accel

### DIFF
--- a/Library/Accel.js
+++ b/Library/Accel.js
@@ -1,0 +1,85 @@
+var util = require('util'),
+    SLCP = require('./SLCP'),
+    EventEmitter = require('events').EventEmitter;
+
+/**
+ * Receiver which listens for accelerometer responses and decode the payload to nice struct
+ *
+ * @param {L8} l8 instance
+ * @param {int?} interval for polling
+ */
+var Accel = function(l8, interval) {
+    this.interval = interval || 500;
+    this.l8 = l8;
+
+    this.receiverId = null;
+
+    this.orientationMap_ = {
+        1: 'up',
+        2: 'down',
+        6: 'left',
+        5: 'right'
+    };
+};
+
+util.inherits(Accel, EventEmitter);
+
+/**
+ * Starts the polling of accel data
+ */
+Accel.prototype.startWatch = function(){
+    this.receiverId = this.l8.registerReceiver(this.onResponse_.bind(this));
+    this.l8.queryAccelerationSensor();
+    // setInterval failed and I don't know why
+    //this.intervalId = setInterval(this.l8.queryAccelerationSensor, this.interval);
+};
+
+/**
+ * Stops accel data polling
+ */
+Accel.prototype.stopWatch = function() {
+    if(this.receiverId) {
+        this.l8.removeReceiver(this.receiverId);
+        clearInterval(this.intervalId);
+    }
+};
+
+/**
+ * Decodes the command payload and transforms it to an object and emit the necessary events
+ *
+ * @param response
+ * @private
+ */
+Accel.prototype.onResponse_ = function(response) {
+    if(response.command === 77) {
+        var parameters = response.parameters,
+            accelData = {
+            'x': parseInt(parameters[0], 16),
+            'y': parseInt(parameters[1], 16),
+            'z': parseInt(parameters[2], 16),
+            'lying':parameters[3] === 02 ? 'up' : 'upside_down',
+            'orientation': this.orientationMap_[parameters[4]],
+            'tap': (parameters[5] === 01),
+            'shake': !(parameters[6] === 00)
+        };
+
+        this.emit('accel', accelData);
+
+        if(accelData.tap) {
+            // Tap is always 01 :(
+            // this.emit('tap');
+        }
+
+        if(accelData.shake) {
+            this.emit('shake');
+        }
+
+        // setInterval failed hard so we do it this way
+        var light = this.l8;
+        setTimeout(function(){
+            light.queryAccelerationSensor()
+        }, this.interval);
+    }
+};
+
+exports.Accel = Accel;

--- a/Library/L8.js
+++ b/Library/L8.js
@@ -441,6 +441,21 @@ L8.prototype.buildFrame = function(command, parametersBuffer) {
 };
 
 /**
+ * Trigger query of the accelerometer
+ *
+ * Register a receiver to get the results.
+ * The decoding should be handled by your receiver.
+ *
+ * @param {Function} fn
+ */
+L8.prototype.queryAccelerationSensor = function(fn) {
+    this.sendFrame(
+        this.buildFrame(SLCP.CMD.L8_ACC_QUERY),
+        true, fn
+    );
+};
+
+/**
  * Ping the L8 in order to check if it is there.
  *
  * The response is currently not handled automatically. If you want to check if

--- a/Library/L8.js
+++ b/Library/L8.js
@@ -796,7 +796,7 @@ L8.prototype.setOrientation = function(orientation, fn) {
         parametersBuffer[0] = 1;
         this.sendFrame(
             this.buildFrame(SLCP.CMD.L8_SET_AUTOROTATE, parametersBuffer),
-            {command: SLCP.CMD.OK, paramerts: new Buffer("6a", "hex")}, fn
+            {command: SLCP.CMD.OK, parameters: new Buffer("6a", "hex")}, fn
         );
     } else {
         // Disable autoration and set orientation manually.

--- a/index.js
+++ b/index.js
@@ -4,3 +4,5 @@ exports.SLCP = require("./Library/SLCP");
 
 exports.L8 = require("./Library/L8").L8;
 Promisify(exports.L8.prototype);
+
+exports.Accel = require('./Library/Accel').Accel;


### PR DESCRIPTION
I added query accelerometer to the protocol.
Decoupled from the L8 lib I created a listener that is able to decode the accelerometer data and triggers easy to process events for shake, tap (broken in l8 FW) and general accel data.
The accel data contains also orientation, position and 3d accel coordinates (x,y,z)

``` javascript
var accel = new Accel(l8, 500); // Create the listener and bind it to the l8

accel.on('accel', function(data) { console.log(data) } ); // get detailed accel data
accel.on('shake', function() { console.log('Twerk, twerk, twerk') } ); // get detailed accel data
accel.on('tap', function() { console.log('BANG') }); // currently disable cause l8 says always it has been tapped.

// Start the polling 
accel.startWatch();
```
